### PR TITLE
Simplify UI to API connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "postinstall": "ng build --prod --output-path dist",
-    "ui-serve": "ng serve",
+    "ui-serve": "ng serve --proxy-config proxy.conf.js",
     "knex:latest": "npx knex migrate:latest",
     "knex:up": "npx knex migrate:up",
     "knex:down": "npx knex migrate:down"

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -1,0 +1,10 @@
+const process = require("process");
+
+const SERVER_PORT = process.env.BACKEND_PORT || 8080;
+const PROXY_CONFIG = [
+  {
+    context: ["/api"],
+    target: `http://localhost:${SERVER_PORT}`,
+  },
+];
+module.exports = PROXY_CONFIG;

--- a/src/app/admin.service.ts
+++ b/src/app/admin.service.ts
@@ -3,8 +3,6 @@ import { Observable, of as observableOf } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { map, catchError } from 'rxjs/operators';
 import {Config} from '@models/config';
-import {environment} from '../environments/environment';
-
 
 @Injectable({
   providedIn: 'root'
@@ -14,7 +12,7 @@ export class AdminService {
   constructor(private http: HttpClient) { }
 
   public getConfig(): Observable<Config> {
-    return this.http.get<Config>(`${environment.restUrl}/api/config`)
+    return this.http.get<Config>('/api/config')
       .pipe(
         map(result => result),
         catchError((err) => {
@@ -25,7 +23,7 @@ export class AdminService {
   }
 
   public updateConfig(config: Config): Observable<void> {
-    return this.http.post(`${environment.restUrl}/api/config`, config)
+    return this.http.post('/api/config', config)
       .pipe(
         catchError((err) => {
           console.error(err);
@@ -35,7 +33,7 @@ export class AdminService {
   }
 
   public submitUserResetImage(requestBody: any): Observable<void> {
-    return this.http.post(`${environment.restUrl}/api/admin/resetUserRegistration`, requestBody)
+    return this.http.post('/api/admin/resetUserRegistration', requestBody)
       .pipe(
         catchError((err) => {
           console.error(err);
@@ -45,7 +43,7 @@ export class AdminService {
   }
 
   public submitConfigChangeByKeyAndValue(requestBody: any): Observable<void> {
-    return this.http.post(`${environment.restUrl}/api/config/change`, requestBody)
+    return this.http.post('/api/config/change', requestBody)
       .pipe(
         catchError((err) => {
           console.error(err);
@@ -56,7 +54,7 @@ export class AdminService {
 
   public authenticateAdmin(requestBody: any): Observable<boolean> {
     console.log('Will call API');
-    return this.http.post<boolean>(`${environment.restUrl}/api/admin/login`, requestBody)
+    return this.http.post<boolean>('/api/admin/login', requestBody)
       .pipe(
         map(result => result),
         catchError((err) => observableOf(false))

--- a/src/app/survey.service.ts
+++ b/src/app/survey.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable, of as observableOf} from 'rxjs';
-import {environment} from '../environments/environment';
 import {catchError, map} from 'rxjs/operators';
 import {SurveyUrls} from '@models/surveyurls';
 import {WhatIsDueResponse} from '@models/whatIsDueResponse';
@@ -14,7 +13,7 @@ export class SurveyService {
   constructor(private http: HttpClient) { }
 
   public findSurveyURLs(accountNumber: number): Observable<SurveyUrls> {
-    return this.http.get<SurveyUrls>(`${environment.restUrl}/api/surveyUrls?accountNumber=${accountNumber}`)
+    return this.http.get<SurveyUrls>(`/api/surveyUrls?accountNumber=${accountNumber}`)
       .pipe(
         map(result => result),
         catchError((err) => {
@@ -25,7 +24,7 @@ export class SurveyService {
   }
 
   public findWhatIsDue(accountNumber: number): Observable<WhatIsDueResponse> {
-    return this.http.get<SurveyUrls>(`${environment.restUrl}/api/member/${accountNumber}/timeline/tasks/open`)
+    return this.http.get<SurveyUrls>(`/api/member/${accountNumber}/timeline/tasks/open`)
       .pipe(
         map(result => result),
         catchError((err) => {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,5 @@
 export const environment = {
   production: true,
-  restUrl: '',
   defaultMemberAuthenticated: false,
   defaultAdminAuthenticated: false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,6 @@
 
 export const environment = {
   production: false,
-  restUrl: 'http://localhost:8080',
   defaultMemberAuthenticated: true, // Controls whether the user has passed member authentication by default.
   defaultAdminAuthenticated: true // Controls whether the user is considered an admin by default.
 };

--- a/src/services/image.service.ts
+++ b/src/services/image.service.ts
@@ -3,7 +3,6 @@ import { Image } from '@models/image';
 import { Observable, of as observableOf } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { map, catchError } from 'rxjs/operators';
-import {environment} from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +11,7 @@ export class ImageService {
   constructor(private http: HttpClient) { }
 
   public validateMemberImage(accountNumber: number, imageId: string): Observable<boolean> {
-    return this.http.post<boolean>(`${environment.restUrl}/api/member/login`, {
+    return this.http.post<boolean>('/api/member/login', {
       accountNumber,
       imageId
     })
@@ -22,7 +21,7 @@ export class ImageService {
     );
   }
   public memberHaveImage(accountNumber: number): Observable<boolean> {
-   return this.http.get<boolean>(`${environment.restUrl}/api/member/registration-check/${accountNumber}`)
+   return this.http.get<boolean>(`/api/member/registration-check/${accountNumber}`)
    .pipe(
      map(result => result),
      catchError((err) => observableOf(false))
@@ -30,7 +29,7 @@ export class ImageService {
   }
 
   public findImages(): Observable<Image[]> {
-    return this.http.get<Image[]>(`${environment.restUrl}/api/images`)
+    return this.http.get<Image[]>('/api/images')
     .pipe(
       map(result => result),
       catchError((err) => {
@@ -41,7 +40,7 @@ export class ImageService {
   }
 
   public updateImage(updateImageReq: any): Observable<void> {
-    return this.http.post(`${environment.restUrl}/api/images`, updateImageReq)
+    return this.http.post('/api/images', updateImageReq)
       .pipe(
         catchError((err) => {
           console.error(err);

--- a/src/services/member.service.ts
+++ b/src/services/member.service.ts
@@ -3,7 +3,6 @@ import { Member } from '@models/member';
 import { Observable, of as observableOf } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { map, catchError } from 'rxjs/operators';
-import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -13,7 +12,7 @@ export class MemberService {
   constructor(private http: HttpClient) { }
 
   public getMember(accountNumber: string): Observable<Member> {
-    return this.http.get<Member>(`${environment.restUrl}/api/member/lookup/${accountNumber}`)
+    return this.http.get<Member>(`/api/member/lookup/${accountNumber}`)
     .pipe(
       map(result => result),
       catchError((err) => {
@@ -24,7 +23,7 @@ export class MemberService {
   }
 
   public isSomethingDue(accountNumber: string): Observable<boolean> {
-    return this.http.get<boolean>(`${environment.restUrl}/api/member/${accountNumber}/timeline/taks/open`)
+    return this.http.get<boolean>(`/api/member/${accountNumber}/timeline/taks/open`)
     .pipe(
       map(result => result),
       catchError((err) => observableOf(false))
@@ -32,7 +31,7 @@ export class MemberService {
   }
 
   public verifyMember(accountNumber: string): Observable<boolean> {
-    return this.http.get<boolean>(`${environment.restUrl}/api/member/verify/${accountNumber}`)
+    return this.http.get<boolean>(`/api/member/verify/${accountNumber}`)
     .pipe(
       map(result => result),
       catchError((err) => observableOf(false))


### PR DESCRIPTION
The app is intended for the API and UI to exist on the same host, so defining a full URL for request is not necessary. This allows us to utilize Webpack's proxy ability to avoid CORS issues when running the UI and API separately for development